### PR TITLE
Drop item by min hits

### DIFF
--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -52,6 +52,7 @@
       var _ret;
       if ((this.data[key] != null) && this._check(key, this.data[key])) {
         this.stats.hits++;
+        this.data[key].hits++;
         _ret = this._unwrap(this.data[key]);
         if (cb != null) {
           cb(null, _ret);
@@ -142,6 +143,24 @@
         cb(null, delCount);
       }
       return delCount;
+    };
+
+    NodeCache.prototype.dropMinHits = function(cb) {
+      var minhits = _.min(this.data, function(value){ return value.hits; }).hits;
+      var keystoremove = [];
+      _.each(this.data, function(value, key){
+        if(value.hits === minhits){
+          keystoremove.push(key);
+        }
+      });
+      if(_.size(keystoremove) > 0) {
+        var del = this.del;
+        _.each(keystoremove, function(value){del(value);});
+      }
+      if(cb != null){
+        cb(null, keystoremove);
+      }
+      return keystoremove;
     };
 
     NodeCache.prototype.ttl = function() {
@@ -265,7 +284,8 @@
       }
       return oReturn = {
         t: livetime,
-        v: value
+        v: value,
+        hits:0,
       };
     };
 

--- a/test/node_cache-test.js
+++ b/test/node_cache-test.js
@@ -42,6 +42,66 @@
   ks = [];
 
   module.exports = {
+    "dropminhits": function(beforeExit, assert) {
+       console.log("\nSTART DROPMINHITS TEST");
+       var value = randomString(10);
+       var value2 = randomString(10);
+       var value3 = randomString(10);
+       var value4 = randomString(10);
+       var key = randomString(5);
+       var key2 = randomString(5);
+       var key3 = randomString(5);
+       var key4 = randomString(5);
+
+       localCache.set(key, value, 1, function(err, res) {
+           assert.isNull(err,err);
+       });
+
+       localCache.set(key2, value2, 1, function(err, res) {
+           assert.isNull(err,err);
+       });
+
+       localCache.set(key3, value3, 1, function(err, res) {
+          assert.isNull(err,err);
+       });
+
+       localCache.set(key4, value4, 1, function(err, res) {
+        assert.isNull(err,err);
+        localCache.get(key, function(err, res){
+          assert.isNull(err, err);
+        });
+        localCache.get(key2, function(err, res){
+          assert.isNull(err, err);
+        });
+        localCache.get(key, function(err, res){
+          assert.isNull(err, err)
+        });
+        localCache.dropMinHits(function(err, res) {
+          //Drop not "popular" items
+          assert.eql(res, [key3, key4]);
+
+          //Try to get value by dropped key3
+          localCache.get(key3, function(err, res){
+            assert.isUndefined(res,res);
+          });
+           
+          //Try to get value by dropped key4
+          localCache.get(key4, function(err, res){
+            assert.isUndefined(res, res);
+          });
+
+        });
+        assert.equal(localCache.getStats().keys,2);
+      });
+
+       localCache.del(key);
+       localCache.del(key2);
+       localCache.del(key3);
+       localCache.del(key4);
+    },
+
+
+
     "general": function(beforeExit, assert) {
       var key, n, start, value, value2;
       console.log("\nSTART GENERAL TEST: " + VCache.version);
@@ -496,7 +556,7 @@
           }, 500);
         });
       });
-    }
+    },
   };
 
 }).call(this);


### PR DESCRIPTION
Hi!
I've just append new feature is dropping key by min hits. For example we have a next keys
Key: number of hits
- A: 5 hits
- B: 5 hits
- C: 1 hits 
- D: 3 hits
- E: 1 hits.

After calling

``` javascript
   myCache.dropMinHits(function(err, droppedkeys){ /*  */});
```

keys C and E is dropped(these keys has a minimum number of hits) and keys A,B and D remains in the cache.

``` javascript
  myCache.get("C", function(err, value){
      //value is undefined, cause key C has been removed.
   });
```

What do you think about this feature?
