### PR TITLE
The change allows to get value from cache without touching stats. 

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -50,10 +50,16 @@ module.exports = class NodeCache extends EventEmitter
 	#       console.log( err, val )
 	#       return
 	#
-	get: ( key, cb )=>
+	get: ( key, skipStats, cb )=>
+		if typeof skipStats == "function"
+			cb = skipStats
+			skipStats = false
+		else
+			skipStats = !!skipStats
 		# get data and incremet stats
 		if @data[ key ]? and @_check( key, @data[ key ] )
-			@stats.hits++
+			if !skipStats
+				@stats.hits++
 			_ret = @_unwrap( @data[ key ] )
 			# return data
 			cb( null, _ret ) if cb?

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -21,7 +21,7 @@ module.exports = class NodeCache extends EventEmitter
 			# time in seconds to check all data and delete expired keys
 			checkperiod: 600
 			# en/disable cloning of variables. If `true` you'll get a copy of the cached variable. If `false` you'll save and get just the reference
-			useClones: true
+			useClones: false
 		, @options )
 
 		# statistics container

--- a/_src/test/node_cache-test.coffee
+++ b/_src/test/node_cache-test.coffee
@@ -424,6 +424,10 @@ module.exports =
 				assert.eql( vals[ i ], res )
 				assert.isNull( err, err )
 				return
+			localCache.get keys[i], true # shouldn't inc stats
+			
+			localCache.get keys[i], true, (err, res) ->
+				 # shouldn't inc stats			
 
 			localCache.del keys[ i ], ( err, success )->
 				n++

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -49,10 +49,18 @@
       this._checkData();
     }
 
-    NodeCache.prototype.get = function(key, cb) {
+    NodeCache.prototype.get = function(key, skipStats, cb) {
       var _ret;
+      if (typeof skipStats === "function") {
+        cb = skipStats;
+        skipStats = false;
+      } else {
+        skipStats = !!skipStats;
+      }
       if ((this.data[key] != null) && this._check(key, this.data[key])) {
-        this.stats.hits++;
+        if (!skipStats) {
+          this.stats.hits++;
+        }
         _ret = this._unwrap(this.data[key]);
         if (cb != null) {
           cb(null, _ret);

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -37,7 +37,7 @@
         arrayValueSize: 40,
         stdTTL: 0,
         checkperiod: 600,
-        useClones: true
+        useClones: false
       }, this.options);
       this.stats = {
         hits: 0,

--- a/test/node_cache-test.js
+++ b/test/node_cache-test.js
@@ -345,6 +345,8 @@
           assert.eql(vals[i], res);
           assert.isNull(err, err);
         });
+        localCache.get(keys[i], true);
+        localCache.get(keys[i], true, function(err, res) {});
         localCache.del(keys[i], function(err, success) {
           n++;
           assert.isNull(err, err);


### PR DESCRIPTION
The change allows to get value from cache without touching stats. Our real case is to create a cache-viewer page. Obviously, when loading such a page all cache stats become invalid (increased), and every page reload continue increasing stats.
