### PR TITLE
Timestamp insertion and getTs to determine age of cached value

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -368,6 +368,52 @@ module.exports = class NodeCache extends EventEmitter
 
 		return
 
+# ## getTs
+#
+# receive the timestamp of a key.
+#
+# **Parameters:**
+#
+# * `key` ( String | Number ): cache key to check the ts value
+# * `[cb]` ( Function ): Callback function
+#
+# **Return**
+#
+# ( Number|undefined ): The timestamp in ms when the key was set or undefined if it does not exist
+#
+# **Example:**
+#
+#     ts = myCache.getTs( "myKey" )
+#
+#     myCache.getTs( "myKey",( err, ts )->
+#       console.log( err, ts )
+#       return
+#
+	getTs: ( key, cb )=>
+		if not key
+			cb( null, undefined ) if cb?
+			return undefined
+
+		# handle invalid key types
+		if (err = @_isInvalidKey( key ))?
+			if cb?
+				cb( err )
+				return
+			else
+				throw err
+
+		# check for existent data and update the ttl value
+		if @data[ key ]? and @_check( key, @data[ key ] )
+			_ts = @data[ key ].ts
+			cb( null, _ts ) if cb?
+			return _ts
+		else
+# return undefined if key has not been found
+			cb( null, undefined ) if cb?
+			return undefined
+
+		return
+
 	# ## keys
 	#
 	# list all keys within this cache
@@ -539,6 +585,7 @@ module.exports = class NodeCache extends EventEmitter
 		# return the wrapped value
 		oReturn =
 			t: livetime
+			ts: now
 			v: if asClone then clone( value ) else value
 
 	# ## _unwrap

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -368,27 +368,27 @@ module.exports = class NodeCache extends EventEmitter
 
 		return
 
-# ## getTs
-#
-# receive the timestamp of a key.
-#
-# **Parameters:**
-#
-# * `key` ( String | Number ): cache key to check the ts value
-# * `[cb]` ( Function ): Callback function
-#
-# **Return**
-#
-# ( Number|undefined ): The timestamp in ms when the key was set or undefined if it does not exist
-#
-# **Example:**
-#
-#     ts = myCache.getTs( "myKey" )
-#
-#     myCache.getTs( "myKey",( err, ts )->
-#       console.log( err, ts )
-#       return
-#
+	# ## getTs
+	#
+	# receive the timestamp of a key.
+	#
+	# **Parameters:**
+	#
+	# * `key` ( String | Number ): cache key to check the ts value
+	# * `[cb]` ( Function ): Callback function
+	#
+	# **Return**
+	#
+	# ( Number|undefined ): The timestamp in ms when the key was set or undefined if it does not exist
+	#
+	# **Example:**
+	#
+	#     ts = myCache.getTs( "myKey" )
+	#
+	#     myCache.getTs( "myKey",( err, ts )->
+	#       console.log( err, ts )
+	#       return
+	#
 	getTs: ( key, cb )=>
 		if not key
 			cb( null, undefined ) if cb?
@@ -408,7 +408,7 @@ module.exports = class NodeCache extends EventEmitter
 			cb( null, _ts ) if cb?
 			return _ts
 		else
-# return undefined if key has not been found
+	# return undefined if key has not been found
 			cb( null, undefined ) if cb?
 			return undefined
 

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -310,7 +310,7 @@ module.exports = class NodeCache extends EventEmitter
 		if @data[ key ]? and @_check( key, @data[ key ] )
 			# if ttl < 0  delete the key. otherwise reset the value
 			if ttl >= 0
-				@data[ key ] = @_wrap( @data[ key ].v, ttl, false )
+				@data[ key ] = @_wrap( @data[ key ].v, ttl, @data[ key ].ts, false )
 			else
 				@del( key )
 			cb( null, true ) if cb?
@@ -402,7 +402,7 @@ module.exports = class NodeCache extends EventEmitter
 			else
 				throw err
 
-		# check for existent data and update the ttl value
+		# check for existent data and update the ts value
 		if @data[ key ]? and @_check( key, @data[ key ] )
 			_ts = @data[ key ].ts
 			cb( null, _ts ) if cb?
@@ -561,7 +561,7 @@ module.exports = class NodeCache extends EventEmitter
 	# ## _wrap
 	#
 	# internal method to wrap a value in an object with some metadata
-	_wrap: ( value, ttl, asClone = true )=>
+	_wrap: ( value, ttl, ts, asClone = true )=>
 		if not @options.useClones
 			asClone = false
 		# define the time to live
@@ -581,6 +581,10 @@ module.exports = class NodeCache extends EventEmitter
 				livetime = @options.stdTTL
 			else
 				livetime = now + ( @options.stdTTL * ttlMultiplicator )
+
+		# if given use timestamp
+		if ts
+			now = ts
 
 		# return the wrapped value
 		oReturn =

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1557,6 +1557,20 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			, 200)
 			return
 
+		it "set another key", () ->
+			localCache.set state.key2, state.val, 0.5, (err, res) ->
+				should.not.exist err
+				true.should.eql res
+			return
+
+		it "update ttl and check that ts does not change", () ->
+			ts1 = localCache.getTs state.key2
+			localCache.ttl state.key2, 0.3, (err, res) ->
+				res.should.eql true
+				should.not.exist err
+				ts2 = localCache.getTs state.key2
+				ts2.should.eql ts1
+			return
 		return
 
 	describe "clone", () ->

--- a/_src/test/typedefinition_test.ts
+++ b/_src/test/typedefinition_test.ts
@@ -95,6 +95,17 @@ interface TypeSample {
 	result2 = cache.getTtl(key, cb);
 }
 
+{
+	let cache: NodeCache;
+	let cb: Callback<Boolean>;
+	let key: string;
+	let number: number;
+	let result1: number | undefined;
+	let result2: Boolean;
+	result1 = cache.getTs(key);
+	result2 = cache.getTs(key, cb);
+}
+
 /* tslint:disable void-return no-void-expression */
 {
 	let cache: NodeCache;

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,16 @@ declare namespace NodeCache {
 			cb?: Callback<boolean>
 		): boolean;
 
+		getTs(
+			key: Key,
+		): number|undefined;
+
+		getTs(
+			key: Key,
+			cb?: Callback<boolean>
+		): boolean;
+
+
 		/**
 		 * list all keys within this cache
 		 * @param cb Callback function
@@ -153,6 +163,7 @@ declare namespace NodeCache {
 	interface WrappedValue<T> {
 		// ttl
 		t: number;
+		ts: number;
 		// value
 		v: T;
 	}
@@ -253,6 +264,15 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	): number|undefined;
 
 	getTtl(
+		key: Key,
+		cb?: Callback<boolean>,
+	): boolean;
+
+	getTs(
+		key: Key
+	): number|undefined;
+
+	getTs(
 		key: Key,
 		cb?: Callback<boolean>,
 	): boolean;


### PR DESCRIPTION
I had need of functionality to determine the "staleness" of the cached value.  Since the TTL can be anything from undefined to infinity there was no fool-proof way of determining this based only on the TTL.  The ts value is set when the cache object is set.  ts is not updated when only ttl is updated on a cache entry.   Added testing for ts.