### PR TITLE
Add size for booleans to _getValLength

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -5,6 +5,7 @@ _isString = require( "lodash/isString" )
 _isFunction = require( "lodash/isFunction" )
 _isNumber = require( "lodash/isNumber" )
 _isObject = require( "lodash/isObject" )
+_isBoolean = require( "lodash/isBoolean" )
 _size = require( "lodash/size" )
 _template = require( "lodash/template" )
 
@@ -583,6 +584,8 @@ module.exports = class NodeCache extends EventEmitter
 		else if _isObject( value )
 			# if the data is an Object multiply each element with a defined default length
 			@options.objectValueSize * _size( value )
+		else if _isBoolean( value )
+		  8
 		else
 			# default fallback
 			0


### PR DESCRIPTION
Currently, booleans are counted as having size 0. This lead to me having a cache that contained lots of values but reported a vsize of 0. 

Quickly redoing the experiment from http://www.mattzeunert.com/2016/07/24/javascript-array-object-sizes.html it seems like V8 treats collections of booleans as oddballs with a size identical to numbers, so I set the size estimate equal to that of numbers (ignoring that both numbers and booleans seem to use closer to 10 bytes).