### PR TITLE
Update get(key) to return undefined when key is expired

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -497,8 +497,8 @@ module.exports = class NodeCache extends EventEmitter
 		# data is invalid if the ttl is to old and is not 0
 		#console.log data.t < Date.now(), data.t, Date.now()
 		if data.t isnt 0 and data.t < Date.now()
+			_retval = false
 			if @options.deleteOnExpire
-				_retval = false
 				@del( key )
 			@emit( "expired", key, @_unwrap(data) )
 

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1414,11 +1414,11 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 				return
 
 
-			it "set a key key with a cache initialized with no automatic delete on expire", (done) ->
+			it "set a key key with a cache initialized with no automatic delete on expire should be undefined", (done) ->
 				localCacheNoDelete.set state.key1, state.val, (err, res) ->
 				setTimeout(() ->
 					res = localCacheNoDelete.get state.key1
-					should(res).eql(state.val)
+					should(res).eql(undefined)
 					done()
 					return
 				, 500)


### PR DESCRIPTION
The docs say that get returns undefined if the key is not found or expired. This update makes it return undefined when the key is expired and deleteOnExpire is false.  Alternately, the docs could be updated  to line up with the behavior of current behavior?